### PR TITLE
fix(context-menu): remove unneccessary wrapping div

### DIFF
--- a/addon/components/nrg-context-menu/component.js
+++ b/addon/components/nrg-context-menu/component.js
@@ -10,6 +10,8 @@ import layout from './template';
 export default Component.extend({
   layout,
 
+  tagName: '',
+
   contextService: service('context-menu'),
 
   options: alias('contextService.contextItems'),


### PR DESCRIPTION
This was causing layout issues within the appbar.

fixes #63 