### PR TITLE
fix(dropdown): "validation" caused dropdown to not close correctly

### DIFF
--- a/addon/components/nrg-dropdown/component.js
+++ b/addon/components/nrg-dropdown/component.js
@@ -27,7 +27,7 @@ export default Component.extend(Validation, {
 
   selection: notEmpty('field'),
 
-  _dropdownClass: computed('selection', 'loading', 'disabled', 'showError', 'class', function() {
+  _dropdownClass: computed('selection', 'loading', 'disabled', 'class', function() {
     let computedClasses = '';
     if (this.get('selection') || this.get('search')) {
       computedClasses += ' selection';


### PR DESCRIPTION
`showError` recomputing could cause the dropdown to not close correctly, and the UI element would "break" the form.

It appears to be on the lines of a race condition because not all validators have the issue.