### PR TITLE
fix(modal): add option to render modal body only after opened

### DIFF
--- a/addon/components/nrg-modal/component.js
+++ b/addon/components/nrg-modal/component.js
@@ -38,6 +38,7 @@ export default Component.extend({
   modalClass: '',
 
   renderBodyAfterOpen: false,
+  showFlashMessages: true,
 
   init() {
     this._super(...arguments);

--- a/addon/components/nrg-modal/component.js
+++ b/addon/components/nrg-modal/component.js
@@ -17,6 +17,9 @@ import {
 } from '@ember/object/computed';
 import Component from '@ember/component';
 import layout from './template';
+import {
+  next
+} from '@ember/runloop';
 
 export default Component.extend({
   layout,
@@ -34,6 +37,8 @@ export default Component.extend({
   transition: 'scale',
   modalClass: '',
 
+  renderBodyAfterOpen: false,
+
   init() {
     this._super(...arguments);
     scheduleOnce('afterRender', this, 'openObserver');
@@ -48,8 +53,12 @@ export default Component.extend({
   }),
 
   openModal() {
-    $(`#${this.elementId}-modal`).modal('show');
-    this.sendAction('onModalOpen');
+    this.set('_isOpen', false);
+    next(() => {
+      $(`#${this.elementId}-modal`).modal('show');
+      this.sendAction('onModalOpen');
+      this.set('_isOpen', true);
+    })
   },
 
   closeModal(sendAction = true) {

--- a/addon/components/nrg-modal/template.hbs
+++ b/addon/components/nrg-modal/template.hbs
@@ -10,9 +10,11 @@
   {{/if}}
 
   <div class="{{if lightbox 'image'}} content">
-    {{#each flashMessages.queue as |flash|}}
-      {{nrg-flash-message flash=flash}}
-    {{/each}}
+    {{#if showFlashMessages}}
+      {{#each flashMessages.queue as |flash|}}
+        {{nrg-flash-message flash=flash}}
+      {{/each}}
+    {{/if}}
     {{#if (or (and renderBodyAfterOpen _isOpen) (not renderBodyAfterOpen))}}
       {{yield}}
     {{/if}}

--- a/addon/components/nrg-modal/template.hbs
+++ b/addon/components/nrg-modal/template.hbs
@@ -13,7 +13,9 @@
     {{#each flashMessages.queue as |flash|}}
       {{nrg-flash-message flash=flash}}
     {{/each}}
-    {{yield}}
+    {{#if (or (and renderBodyAfterOpen _isOpen) (not renderBodyAfterOpen))}}
+      {{yield}}
+    {{/if}}
   </div>
 
   {{#if hasButtons}}

--- a/tests/dummy/app/view-components/nrg-modal/template.hbs
+++ b/tests/dummy/app/view-components/nrg-modal/template.hbs
@@ -70,23 +70,39 @@
     <div class='ui segment teal'>In order for modals to nest correctly, the modal on bottom must be first in the DOM</div>
     {{#nrg-form-container as |form|}}
       {{#form.field as |field|}}
-        {{nrg-checkbox type='toggle' label='Open Modal' checked=modalOpen1}}
+        {{field.checkbox type='toggle' label='Open Modal' checked=modalOpen1}}
       {{/form.field}}
       {{#form.field as |field|}}
-        {{nrg-checkbox type='toggle' label='Open Modal with Actions' checked=modalOpen3}}
+        {{field.checkbox type='toggle' label='Open Modal with Actions' checked=modalOpen3}}
       {{/form.field}}
       {{#form.field as |field|}}
-        {{nrg-checkbox type='toggle' label='Open Modal (Not Dismissable)' checked=modalOpen5}}
+        {{field.checkbox type='toggle' label='Open Modal (Not Dismissable)' checked=modalOpen5}}
       {{/form.field}}
     {{/nrg-form-container}}
 
     <div class='ui segment red'>Do not use basic modals when nesting</div>
     {{#nrg-form-container as |form|}}
       {{#form.field as |field|}}
-        {{nrg-checkbox type='toggle' label='Open Basic Modal' checked=modalOpen2}}
+        {{field.checkbox type='toggle' label='Open Basic Modal' checked=modalOpen2}}
       {{/form.field}}
       {{#form.field as |field|}}
-        {{nrg-checkbox type='toggle' label='Open Basic Modal with Actions' checked=modalOpen4}}
+        {{field.checkbox type='toggle' label='Open Basic Modal with Actions' checked=modalOpen4}}
+      {{/form.field}}
+    {{/nrg-form-container}}
+  {{/nrg-modal}}
+  <!-- END-SNIPPET  -->
+{{/nrg-code-block}}
+
+{{#nrg-code-block label='Datetime component in Modal' codeBlockName='datetime-modal.hbs' }}
+  {{nrg-button text='Open Modal' action=(action (mut modalOpen7) true)}}
+  <!-- BEGIN-SNIPPET datetime-modal -->
+  <!-- The datetime uses a semantic popup. Due to changes within Semantic, the popup has to be rendered after the modal is open to work correctly. -->
+  <!-- The "renderBodyAfterOpen" flag tells the component not to render the body below until the body is open. -->
+  <!-- The default behavior is to render "always" -->
+  {{#nrg-modal renderBodyAfterOpen=true headerText='Datetime component inside a modal' isOpen=modalOpen7}}
+    {{#nrg-form-container as |form|}}
+      {{#form.field as |field|}}
+        {{field.datetime}}
       {{/form.field}}
     {{/nrg-form-container}}
   {{/nrg-modal}}


### PR DESCRIPTION
This PR is in response to this issue from Semantic UI. https://github.com/Semantic-Org/Semantic-UI/issues/4860#issuecomment-297702810

It was discovered that the popup for the datetime component was getting destroyed when inside of a modal.