### PR TITLE
chore: bump package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-nrg-ui",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Opinionated UI addon based on how KUB scaffolds web applications",
   "keywords": ["ember-addon", "Semantic UI"],
   "repository": {


### PR DESCRIPTION
1.2.2 was previously used for a test npm publish and can't be overidden