### PR TITLE
fix: toggling sidebar didn't work on big screens

### DIFF
--- a/addon/components/nrg-application/component.js
+++ b/addon/components/nrg-application/component.js
@@ -1,6 +1,6 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
-import { alias, and, or, reads } from '@ember/object/computed';
+import { alias, and, reads } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
 import { htmlSafe } from '@ember/string';
 import ResizeMixin from 'ember-nrg-ui/mixins/resize';
@@ -27,7 +27,7 @@ export default Component.extend(ResizeMixin, {
 
   classNameBindings: ['fullscreenMap:fullscreen-map', 'computerScreenSidebarActive:large-screen-sidebar-active'],
 
-  isComputerScreen: or('responsive.isComputerScreen', 'responsive.isLargeMonitor', 'responsive.isWidescreenMonitor'),
+  isComputerScreen: alias('responsive.isComputerScreenGroup'),
 
   title: reads('application.pageTitle'),
 

--- a/addon/instance-initializers/breakpoints-override.js
+++ b/addon/instance-initializers/breakpoints-override.js
@@ -6,6 +6,5 @@ export function initialize(application) {
 }
 
 export default {
-  after: 'ember-responsive-breakpoints',
   initialize
 };

--- a/app/initializers/breakpoints-override.js
+++ b/app/initializers/breakpoints-override.js
@@ -1,1 +1,0 @@
-export { default, initialize } from 'ember-nrg-ui/initializers/breakpoints-override';

--- a/app/instance-initializers/breakpoints-override.js
+++ b/app/instance-initializers/breakpoints-override.js
@@ -1,0 +1,1 @@
+export { default, initialize } from 'ember-nrg-ui/instance-initializers/breakpoints-override';

--- a/tests/unit/instance-initializers/breakpoints-override-test.js
+++ b/tests/unit/instance-initializers/breakpoints-override-test.js
@@ -1,10 +1,10 @@
 import Application from '@ember/application';
 
-import { initialize } from 'dummy/initializers/breakpoints-override';
+import { initialize } from 'dummy/instance-initializers/breakpoints-override';
 import { module, test } from 'qunit';
 import { run } from '@ember/runloop';
 
-module('Unit | Initializer | breakpoints-override', function(hooks) {
+module('Unit | Instance Initializer | breakpoints-override', function(hooks) {
   hooks.beforeEach(function() {
     this.TestApplication = Application.extend();
     this.TestApplication.initializer({


### PR DESCRIPTION
This was caused by a change after new release to prevent apps from having to declare a `breakpoints.js` in the app. Due to timing, this needs to be a instance-initializer instead of an initializer.