### PR TITLE
fix(dropdown/item): Pass extra attributes to div

### DIFF
--- a/addon/components/nrg-dropdown/item/template.hbs
+++ b/addon/components/nrg-dropdown/item/template.hbs
@@ -1,3 +1,3 @@
-<div data-dropdown-item="true" role="button" class="{{if disabled "disabled"}} {{if active "active"}} item" {{action _onClick option preventDefault=false}}>
+<div data-dropdown-item="true" role="button" class="{{if disabled "disabled"}} {{if active "active"}} item" {{action _onClick option preventDefault=false}} ...attributes>
   {{yield}}
 </div>


### PR DESCRIPTION
Attempting to pass extra attributes, notably `data-test-*` attributes to an item in the dropdown would skip the attributes in rendering.