### PR TITLE
fix(dropdown): Allow searching of object fields that contain numeric values

### DIFF
--- a/addon/components/nrg-dropdown/component.js
+++ b/addon/components/nrg-dropdown/component.js
@@ -209,7 +209,12 @@ export default Component.extend(Validation, EKMixin, EKFirstResponderOnFocusMixi
     if (typeof option == 'string') {
       return this.stringContains(option, searchValue);
     } else if (this.searchProperty) {
-      return this.stringContains(option[this.searchProperty], searchValue);
+      const optionAttribute = option[this.searchProperty]
+      if(optionAttribute && typeof optionAttribute == 'string'){
+        return this.stringContains(optionAttribute, searchValue);
+      } else if (optionAttribute && typeof optionAttribute == 'number'){
+        return this.stringContains(optionAttribute.toString(), searchValue);
+      }
     } else {
       return this.stringContains(option.label, searchValue) || this.stringContains(option.value, searchValue);
     }

--- a/addon/components/nrg-text-field/trim-input/component.js
+++ b/addon/components/nrg-text-field/trim-input/component.js
@@ -15,8 +15,14 @@ export default Component.extend({
     },
     set(key, value) {
       const oldValue = this.get('value');
-      const newValue = (value && value.trim()) || '';
-      if (oldValue !== newValue) {
+      let newValue;
+      if(value && typeof(value) == 'string'){
+        newValue = value.trim() || '';
+      } else if (value && typeof(value) == 'number') {
+        newValue = value.toString() || '';
+      }
+
+      if(oldValue !== newValue){
         this.set('_value', newValue);
       }
     },


### PR DESCRIPTION
While investigating a bug in the Mobile I noticed that the Meter field in the CIS workflow wasn't searchable as it was before upgrading the API. It turns out we were only searching strings.

This PR allows numeric fields to be searchable by always stringifying the value of the field being passed in via searchProperty.