### PR TITLE
fix: sidebar role error when unauthenticated

### DIFF
--- a/addon/sidebar-menu-manager/service.js
+++ b/addon/sidebar-menu-manager/service.js
@@ -45,10 +45,13 @@ export default Service.extend({
 
   _menuItemsRoleFiltered: computed('_menuItems.[]', 'currentUser.roles.[]', function() {
     return this.get('_menuItems').filter(item => {
+      const currentUserContent = this.get('currentUser.content');
       if (!item.sidebarRole) {
         return true;
       }
-      const currentUserContent = this.get('currentUser.content');
+      if (!currentUserContent) {
+        return false;
+      }
       const roles = Array.isArray(item.sidebarRole) ? item.sidebarRole : [item.sidebarRole];
       if (item.needsAllRoles) {
         return roles.every(role => currentUserContent.hasRole(role));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-nrg-ui",
-  "version": "2.3.4",
+  "version": "2.3.5",
   "description": "Opinionated UI addon based on how KUB scaffolds web applications",
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
Current user content was null when unauthenticated and caused an error when trying to call `hasRole()`.