### PR TITLE
fix: Potential chrome connection fix

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -10,7 +10,7 @@ module.exports = function(defaults) {
     fingerprint: {
       enabled: env === 'review' || env === 'production',
       prepend: process.env.rootURL || '/',
-      exclude: ['images/nrg-logo'],
+      exclude: ['images/nrg-logo', 'testem'],
       extensions: ['js', 'css', 'png', 'jpg', 'gif', 'map', 'svg'],
     },
     'ember-cli-babel': {


### PR DESCRIPTION
I was reading where Robert Jackson (rwjblue) had said a fix to prevent testem.js from being fingerprinted was released in 3.11. Possibly a coincidence this didn't fail on the first attempt as so many PR's have been doing lately, or maybe I held my tongue right as I pushed the button.