### PR TITLE
style(dropdown): Force dropdowns to have same font size as input

### DIFF
--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -20,10 +20,20 @@ $appbar-color: #232845;
 @import 'popup';
 
 // https://stackoverflow.com/questions/2989263/disable-auto-zoom-in-input-text-tag-safari-on-iphone
+$input-size: 16px !important;
+
 input,
 select,
 textarea {
-  font-size: 16px !important;
+  font-size: $input-size;
+}
+
+.ui.dropdown.selection {
+  font-size: $input-size;
+
+  .item {
+    font-size: $input-size;
+  }
 }
 
 [data-ember-action] {


### PR DESCRIPTION
The modified Sass isn't the prettiest and I'm sure it could be written in a cleaner way, so I am open to feedback.