### PR TITLE
fix(modal-wrapper): Add dependent key for scrolling

### DIFF
--- a/addon/components/nrg-modal-container/modal-wrapper/component.js
+++ b/addon/components/nrg-modal-container/modal-wrapper/component.js
@@ -81,6 +81,7 @@ export default Component.extend(ResizeMixin, {
     'lightbox',
     'renderInPlace',
     'masterDetail',
+    'scrolling',
     function() {
       const appliedClasses = ['modal-content'];
       if (this.lightbox) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-nrg-ui",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "Opinionated UI addon based on how KUB scaffolds web applications",
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
When `this.scrolling` was accessed on L92, it was returning `undefined` because the computed property `nrg-modal#scrolling` was never firing. This adds that dependent key to force the CP to recalculate and properly compute.