### PR TITLE
 refactor(dropdown): improve keyboard navigation

### DIFF
--- a/addon/components/nrg-dropdown/component.js
+++ b/addon/components/nrg-dropdown/component.js
@@ -11,6 +11,11 @@ import layout from './template';
 export default Component.extend(Validation, EKMixin, EKFirstResponderOnFocusMixin, {
   layout,
   tagName: 'div',
+  attributeBindings : ['tabindex'],
+
+  tabindex: computed('search', function() {
+    return this.search ? null : "0";
+  }),
 
   defaultText: 'Select an Option',
   disabled: false,
@@ -29,6 +34,7 @@ export default Component.extend(Validation, EKMixin, EKFirstResponderOnFocusMixi
   isOpen: false,
   searchProperty: undefined,
   activeItem: -1,
+  _dropdownDisabled: or('disabled', 'loading'), 
 
   classNames: ['ui', 'dropdown'],
   classNameBindings: [
@@ -56,6 +62,29 @@ export default Component.extend(Validation, EKMixin, EKFirstResponderOnFocusMixi
     return this.get('options.length') && typeof this.options[0] == 'string';
   }),
 
+  searchPlaceholder: computed('activeItem', function() {
+    if (this.activeItem === -1 || this.multiple || !this.isSearching) {
+      return '';
+    }
+    const option = this.displayedOptions[this.activeItem];
+    if (this.isStringData) {
+      return option || '';
+    }
+    
+    if (!option) {
+      return '';
+    }
+
+    if (!option.label) {
+      const item = this.element.querySelector(`[data-dropdown-index="${this.activeItem}"]`);
+      if (item) {
+        const text = item.textContent;
+        return text && text.trim() || '';
+      }
+    }
+    return option.label || ''
+  }),
+
   init() {
     this._super(...arguments);
     this.optionsObserver();
@@ -63,14 +92,11 @@ export default Component.extend(Validation, EKMixin, EKFirstResponderOnFocusMixi
 
   didInsertElement() {
     this._super(...arguments);
-    this.createMouseEnterHandler();
-    this.createMouseLeaveHandler();
     this.createClickHandler();
   },
 
   willDestroyElement() {
     this._super(...arguments);
-    this.removeMouseListeners();
     this.removeWindowClickListener();
   },
 
@@ -82,58 +108,40 @@ export default Component.extend(Validation, EKMixin, EKFirstResponderOnFocusMixi
     document.removeEventListener('click', this._clickHandler, true);
   },
 
-  addMouseListeners() {
-    document.addEventListener('mouseenter', this._mouseEnterHandler, true);
-    document.addEventListener('mouseleave', this._mouseLeaveHandler, true);
-  },
-
-  removeMouseListeners() {
-    document.removeEventListener('mouseenter', this._mouseEnterHandler, true);
-    document.removeEventListener('mouseleave', this._mouseLeaveHandler, true);
-  },
-
-  createMouseEnterHandler() {
-    this.set('_mouseEnterHandler', evt => {
-      if (this.element && this.element.contains(evt.target)) {
-        const item = evt.target.closest('[data-dropdown-item]');
-        if(item) {
-          const index = item.dataset.dropdownIndex;
-          this.set('activeItem', index);
-        }
-      }
-    });
-  },
-
-  createMouseLeaveHandler() {
-    this.set('_mouseLeaveHandler', evt => {
-      if (this.element && !this.element.contains(evt.target)) {
-        this.set('activeItem', -1);
-      }
-    });
-  },
-
   createClickHandler() {
     this.set('_clickHandler', evt => {
       if (this.element && !this.element.contains(evt.target)) {
-        this.set('isOpen', false);
+        if (this.activeItem !== -1) {
+          this._onSelect(this.options[this.activeItem]);
+        }
+        this.closeDropdown();
         this.set('activeItem', -1);
-        this.focusInput(false);
       }
       return true;
     });
   },
 
-  isOpenObserver: observer('isOpen', function() {
+  openDropdown() {
+    if (this.isOpen) {
+      return;
+    }
     next(() => {
-      if (this.get('isOpen')) {
-        this.addWindowClickListener();
-        this.addMouseListeners();
-      } else {
-        this.removeMouseListeners();
-        this.removeWindowClickListener();
-      }
+      this.set('isOpen', true);
+      this.addWindowClickListener();
+      this.focusInput(true);
     });
-  }),
+  },
+
+  closeDropdown() {
+    if (!this.isOpen) {
+      return;
+    }
+    next(() => {
+      this.set('isOpen', false);
+      this.focusInput(false);
+      this.removeWindowClickListener();
+    });
+  },
 
   optionsObserver: observer('options', function() {
     this.set('activeItem', -1);
@@ -145,8 +153,30 @@ export default Component.extend(Validation, EKMixin, EKFirstResponderOnFocusMixi
     });
   }),
 
-  moveUp: on(keyDown('ArrowUp'), function(evt) {
+  keyboardEscapeHandler: on(keyDown('Enter'), keyDown('NumpadEnter'), keyDown('Tab'), keyDown('Escape'), function(evt) {
+    if (this._dropdownDisabled) {
+      return;
+    }
+    const displayedOptionsLength = this.get('displayedOptions.length');
+    const isSearchAndFoundResults = this.isSearching && displayedOptionsLength > 0;
+    if(isSearchAndFoundResults) {
+      this.set('activeItem', 0);
+    }
+    const validRange = this.activeItem >= 0 && this.activeItem < displayedOptionsLength;
     if (!this.isOpen) {
+      return;
+    }
+    evt.preventDefault();
+    evt.stopPropagation();
+    if (validRange) {
+      this._onSelect(this.displayedOptions[this.activeItem]);
+    } else {
+      this.closeDropdown();
+    }
+  }),
+
+  moveUp: on(keyDown('ArrowUp'), function(evt) {
+    if (!this.isOpen || this._dropdownDisabled) {
       return;
     }
     evt.preventDefault();
@@ -158,7 +188,7 @@ export default Component.extend(Validation, EKMixin, EKFirstResponderOnFocusMixi
   }),
 
   moveDown: on(keyDown('ArrowDown'), function(evt) {
-    if (!this.isOpen) {
+    if (!this.isOpen || this._dropdownDisabled) {
       return;
     }
     evt.preventDefault();
@@ -176,21 +206,6 @@ export default Component.extend(Validation, EKMixin, EKFirstResponderOnFocusMixi
     }
     item.scrollIntoView(false);
   },
-
-  enter: on(keyDown('Enter'), keyDown('NumpadEnter'), function(evt) {
-    const displayedOptionsLength = this.get('displayedOptions.length');
-    const isSearchAndFoundSingleResult = this.isSearching && displayedOptionsLength === 1;
-    if(isSearchAndFoundSingleResult) {
-      this.set('activeItem', 0);
-    }
-    const validRange = this.activeItem >= 0 && this.activeItem < displayedOptionsLength;
-    if (!this.isOpen || !validRange) {
-      return;
-    }
-    evt.preventDefault();
-    evt.stopPropagation();
-    this._onSelect(this.displayedOptions[this.activeItem]);
-  }),
 
   menuClass: computed('menuDirection', 'isOpen', function() {
     let computedClasses = '';
@@ -232,25 +247,23 @@ export default Component.extend(Validation, EKMixin, EKFirstResponderOnFocusMixi
         options = options.filter(option => {
           return !this.isCurrentlySelected(option);
         });
-      }
-      if (!this.isSearching) {
+      } else if (!this.isSearching) {
         return options;
-      } else {
-        const filteredOptions = options.filter(option => {
-          return this.isSearchMatch(option, this.searchValue);
-        });
-        if (this.allowAdditions && filteredOptions.length == 0) {
-          this.set('isAddingOption', true);
-          const addedOption = this.isStringData
-            ? this.searchValue
-            : {
-                label: this.searchValue,
-                value: this.searchValue,
-              };
-          return [addedOption];
-        } else {
-          return filteredOptions;
+      }
+      const filteredOptions = options.filter(option => {
+        return this.isSearchMatch(option, this.searchValue);
+      });
+      if (this.allowAdditions && filteredOptions.length == 0) {
+        this.set('isAddingOption', true);
+        if (this.isStringData) {
+          return [this.searchValue]
         }
+        return [{
+          label: this.searchValue,
+          value: this.searchValue,
+        }];
+      } else {
+        return filteredOptions;
       }
     }
   ),
@@ -280,22 +293,45 @@ export default Component.extend(Validation, EKMixin, EKFirstResponderOnFocusMixi
     return s1.toLowerCase().indexOf(s2.toLowerCase()) != -1;
   },
 
-  click(evt) {
+  mouseDown(evt) {
     const isMultiSelection = evt.target.closest('[data-dropdown-multi-selection]');
     const isDropdownItem = evt.target.closest('[data-dropdown-item]');
     if (isMultiSelection || isDropdownItem) {
+      return false;
+    }
+    const isDropdownIcon = evt.target.closest('.dropdown.icon');
+    if (this.search && !this.isOpen) {
+      this.openDropdown();
+    } else if (!this.search || isDropdownIcon) {
+      if (this.isOpen) {
+        this.closeDropdown();
+      } else {
+        this.openDropdown();
+      }
+    }
+  },
+
+  focusIn() {
+    if (this._dropdownDisabled) {
       return;
     }
-    if (this.isOpen) {
-      this.set('isOpen', false);
-    } else {
-      this.set('isOpen', true);
+    if (this.showOnFocus) {
+      this.openDropdown()
+    }
+    if (this.search) {
       this.focusInput(true);
     }
   },
 
+  focusOut(evt) {
+    if (evt.relatedTarget && evt.relatedTarget.closest('.visible.menu')) {
+      return;
+    }
+    this.closeDropdown();
+  },
+
   focusInput(focus) {
-    if (!this.search) {
+    if (!this.search || this._dropdownDisabled) {
       return;
     }
     const input = this.element.querySelector('input');
@@ -307,13 +343,8 @@ export default Component.extend(Validation, EKMixin, EKFirstResponderOnFocusMixi
     }
   },
 
-  onInputFocus() {
-    // do not propagate event
-    return false;
-  },
-
-  onInputChange() {
-    this.set('isOpen', true);
+  onSearchInputChange() {
+    this.openDropdown();
     this.focusInput(true);
   },
 
@@ -333,9 +364,8 @@ export default Component.extend(Validation, EKMixin, EKFirstResponderOnFocusMixi
   },
 
   _onSelect(option) {
-    if (!option) {
-      this.set('isOpen', false);
-      this.focusInput(false);
+    if (!option || this._dropdownDisabled) {
+      this.closeDropdown();
     }
     const notCurrentlySelected = !this.isCurrentlySelected(option);
     if (notCurrentlySelected) {
@@ -358,8 +388,7 @@ export default Component.extend(Validation, EKMixin, EKFirstResponderOnFocusMixi
       this.get('options.push') && this.options.push(option);
     }
     if (!this.multiple) {
-      this.set('isOpen', false);
-      this.focusInput(false);
+      this.closeDropdown();
     }
     this.set('isAddingOption', false);
     this.set('activeItem', -1);

--- a/addon/components/nrg-dropdown/component.js
+++ b/addon/components/nrg-dropdown/component.js
@@ -307,6 +307,16 @@ export default Component.extend(Validation, EKMixin, EKFirstResponderOnFocusMixi
     }
   },
 
+  onInputFocus() {
+    // do not propagate event
+    return false;
+  },
+
+  onInputChange() {
+    this.set('isOpen', true);
+    this.focusInput(true);
+  },
+
   isCurrentlySelected(option) {
     if (this.multiple) {
       if (!Array.isArray(this.selected)) {

--- a/addon/components/nrg-dropdown/component.js
+++ b/addon/components/nrg-dropdown/component.js
@@ -125,22 +125,18 @@ export default Component.extend(Validation, EKMixin, EKFirstResponderOnFocusMixi
     if (this.isOpen) {
       return;
     }
-    next(() => {
-      this.set('isOpen', true);
-      this.addWindowClickListener();
-      this.focusInput(true);
-    });
+    this.set('isOpen', true);
+    this.addWindowClickListener();
+    this.focusInput(true);
   },
 
   closeDropdown() {
     if (!this.isOpen) {
       return;
     }
-    next(() => {
-      this.set('isOpen', false);
-      this.focusInput(false);
-      this.removeWindowClickListener();
-    });
+    this.set('isOpen', false);
+    this.focusInput(false);
+    this.removeWindowClickListener();
   },
 
   optionsObserver: observer('options', function() {
@@ -324,7 +320,7 @@ export default Component.extend(Validation, EKMixin, EKFirstResponderOnFocusMixi
   },
 
   focusOut(evt) {
-    if (evt.relatedTarget && evt.relatedTarget.closest('.visible.menu')) {
+    if (evt.target && evt.target.closest('.dropdown')) {
       return;
     }
     this.closeDropdown();
@@ -336,7 +332,9 @@ export default Component.extend(Validation, EKMixin, EKFirstResponderOnFocusMixi
     }
     const input = this.element.querySelector('input');
     if (focus) {
-      input.focus();
+      next(() => {
+        input.focus();
+      });
     } else {
       this.set('searchValue', '');
       input.blur();
@@ -345,7 +343,6 @@ export default Component.extend(Validation, EKMixin, EKFirstResponderOnFocusMixi
 
   onSearchInputChange() {
     this.openDropdown();
-    this.focusInput(true);
   },
 
   isCurrentlySelected(option) {

--- a/addon/components/nrg-dropdown/template.hbs
+++ b/addon/components/nrg-dropdown/template.hbs
@@ -43,7 +43,7 @@
     {{/each}}
   {{/if}}
   {{#if search}}
-    <Input @class="search" @autocomplete="off" @name={{name}} @value={{searchValue}} />
+    <Input @class="search" @autocomplete="off" @name={{name}} @value={{searchValue}} @focus={{action onInputFocus}} @input={{action onInputChange}} />
   {{/if}}
   {{#if (and search multiple)}}
     <span class="sizer"></span>

--- a/addon/components/nrg-dropdown/template.hbs
+++ b/addon/components/nrg-dropdown/template.hbs
@@ -13,7 +13,7 @@
     <i class="icon {{icon}}"></i>
   {{/if}}
 
-  {{#unless multiple}}
+  {{#if (and (not multiple) (not searchPlaceholder))}}
     <div class="{{textClass}} text">
       {{#if hasSelected}}
         {{#if hasBlock}}
@@ -27,7 +27,7 @@
         {{defaultText}}
       {{/if}}
     </div>
-  {{/unless}}
+  {{/if}}
   {{#if (and hasSelected multiple)}}
     {{#each selected as |selectedOption|}}
       <a data-dropdown-multi-selection="true" class="ui label transition visible">
@@ -43,13 +43,13 @@
     {{/each}}
   {{/if}}
   {{#if search}}
-    <Input @class="search" @autocomplete="off" @name={{name}} @value={{searchValue}} @focus={{action onInputFocus}} @input={{action onInputChange}} />
+    <Input tabindex="0" @class="search" @autocomplete="off" @name={{name}} @placeholder={{searchPlaceholder}} @value={{searchValue}} @input={{action onSearchInputChange}} />
   {{/if}}
   {{#if (and search multiple)}}
     <span class="sizer"></span>
   {{/if}}
   <i class="dropdown icon"></i>
-  <div class="{{menuClass}} menu">
+  <div class="{{menuClass}} menu" tabindex="-1">
     {{#each displayedOptions as |option i|}}
       <NrgDropdown::Item @option={{option}} @disabled={{option.disabled}} @index={{i}} @activeItem={{activeItem}} @_onSelect={{action _onSelect}}>
         {{#if hasBlock}}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-nrg-ui",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "description": "Opinionated UI addon based on how KUB scaffolds web applications",
   "keywords": [
     "ember-addon",

--- a/tests/integration/components/nrg-dropdown/component-test.js
+++ b/tests/integration/components/nrg-dropdown/component-test.js
@@ -1,7 +1,8 @@
-import { find, render } from '@ember/test-helpers';
+import { click, find, fillIn, focus, render } from '@ember/test-helpers';
 import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import { module, test } from 'qunit';
+import { triggerKeyDown } from 'ember-keyboard';
 
 module('Integration | Component | nrg-dropdown', function(hooks) {
   hooks.beforeEach(() => {
@@ -15,7 +16,6 @@ module('Integration | Component | nrg-dropdown', function(hooks) {
         label2: 'Label2 2',
       },
     ];
-
     this.selectedOption = this.options[1];
   });
 
@@ -47,5 +47,93 @@ module('Integration | Component | nrg-dropdown', function(hooks) {
     `);
 
     assert.equal(find('.text').textContent.trim(), 'Label2 2');
+  });
+
+  test('menu keyboard navigation - arrow down', async function(assert) {
+    this.options = [
+      {
+        label: 'Option 1',
+        value: 'Value 1',
+      },
+      {
+        label: 'Option 2',
+        value: 'Value 2',
+      },
+    ];
+    await render(hbs`<NrgDropdown @options={{options}} />`);
+    await click('.dropdown');
+    await triggerKeyDown('ArrowDown');
+    await triggerKeyDown('ArrowDown');
+    await triggerKeyDown('Enter');
+    assert.equal(find('.text').textContent.trim(), 'Option 2');
+  });
+
+  test('menu keyboard navigation - arrow up', async function(assert) {
+    this.options = [
+      {
+        label: 'Option 1',
+        value: 'Value 1',
+      },
+      {
+        label: 'Option 2',
+        value: 'Value 2',
+      },
+    ];
+    await render(hbs`<NrgDropdown @options={{options}} />`);
+    await click('.dropdown');
+    await triggerKeyDown('ArrowDown');
+    await triggerKeyDown('ArrowDown');
+    await triggerKeyDown('ArrowUp');
+    await triggerKeyDown('Enter');
+    assert.equal(find('.text').textContent.trim(), 'Option 1');
+  });
+
+  test('menu keyboard navigation - select and tab', async function(assert) {
+    this.options = [
+      {
+        label: 'Option 1',
+        value: 'Value 1',
+      },
+      {
+        label: 'Option 2',
+        value: 'Value 2',
+      },
+    ];
+    await render(hbs`<NrgDropdown @options={{options}} />`);
+    await click('.dropdown');
+    await triggerKeyDown('ArrowDown');
+    await triggerKeyDown('ArrowDown');
+    await triggerKeyDown('Tab');
+    assert.equal(find('.text').textContent.trim(), 'Option 2');
+  });
+
+  test('menu keyboard navigation - search and tab', async function(assert) {
+    this.options = [
+      {
+        label: 'Option 1',
+        value: 'Value 1',
+      },
+      {
+        label: 'Option 2',
+        value: 'Value 2',
+      },
+    ];
+    await render(hbs`<NrgDropdown @search={{true}} @options={{options}} />`);
+    await click('.dropdown');
+    await fillIn('input', '2');
+    await triggerKeyDown('Tab');
+    assert.equal(find('.text').textContent.trim(), 'Option 2');
+  });
+
+  test('open dropdown with dom focus', async function(assert) {
+    this.options = [
+      {
+        label: 'Option 1',
+        value: 'Value 1',
+      },
+    ];
+    await render(hbs`<NrgDropdown @search={{true}} @options={{options}} />`);
+    await focus('input')
+    assert.ok(find('.dropdown.visible'));
   });
 });


### PR DESCRIPTION
This PR allows the dropdown to conform to keyboard typists using `Tab` and `Escape`. 
There are changes to better match Fomantic/Semantic JS version of the dropdown like adding the search placeholder.