### PR TITLE
fix: Make context menu accessible when flash messages are present

### DIFF
--- a/addon/styles/_flash-messages.scss
+++ b/addon/styles/_flash-messages.scss
@@ -1,9 +1,14 @@
 .nrg-application {
   .toast-container {
-    padding-top: $appbar-height;
+    margin-top: $appbar-height;
 
     .ui.ui.progress.error .bar {
       background-color: #541212;
     }
   }
+}
+
+.ui.toast-container {
+  position: fixed;
+  z-index: 50;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-nrg-ui",
-  "version": "2.5.5",
+  "version": "2.5.6",
   "description": "Opinionated UI addon based on how KUB scaffolds web applications",
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
Changed padding to margin which enables a click to pass through the toast-container to the context menu and version number.

Overrode the ui.toast-container to utilize a more purposeful z-index (9999 default) to allow the context menu to overlap flash messages in the event they are present and the user wants to view the context menu. #303 