### PR TITLE
fix: app version

### DIFF
--- a/addon/helpers/nrg-app-version.js
+++ b/addon/helpers/nrg-app-version.js
@@ -1,18 +1,23 @@
 import { helper } from '@ember/component/helper';
 import config from 'ember-get-config';
-import { shaRegExp } from 'ember-cli-app-version/utils/regexp';
+import {
+  shaRegExp,
+  versionExtendedRegExp,
+  versionRegExp,
+} from 'ember-cli-app-version/utils/regexp';
 
 const {
-  APP: { version },
+  APP: { version, commitsSinceLastTag },
 } = config;
 
 export function appVersion() {
-  const parts = version.split('+');
-  const isTag = parts.length === 1;
-  let displayVersion = `${version}`;
+  const isTag = commitsSinceLastTag == 0;
+  let displayVersion =
+    version.match(versionExtendedRegExp)?.[0] ??
+    version.match(versionRegExp)?.[0];
 
   if (!isTag) {
-    displayVersion = version.match(shaRegExp)[0];
+    displayVersion = version.match(shaRegExp)?.[0];
   }
 
   return displayVersion;

--- a/addon/helpers/nrg-app-version.js
+++ b/addon/helpers/nrg-app-version.js
@@ -12,15 +12,13 @@ const {
 
 export function appVersion() {
   const isTag = commitsSinceLastTag == 0;
-  let displayVersion =
-    version.match(versionExtendedRegExp)?.[0] ??
-    version.match(versionRegExp)?.[0];
-
   if (!isTag) {
-    displayVersion = version.match(shaRegExp)?.[0];
+    return version.match(shaRegExp)?.[0];
   }
-
-  return displayVersion;
+  return (
+    version.match(versionExtendedRegExp)?.[0] ??
+    version.match(versionRegExp)?.[0]
+  );
 }
 
 export default helper(appVersion);

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 'use strict';
 const path = require('path');
 const walkSync = require('walk-sync');
+const getGitInfo = require('git-repo-info');
 
 module.exports = {
   name: require('./package').name,
@@ -37,5 +38,15 @@ module.exports = {
     const plugin = new MarkdownTemplateCompiler();
     registry.instantiatedPlugins.push(plugin);
     registry.registeredForType('template').unshift(plugin);
+  },
+
+  config(env, baseConfig) {
+    let config = this._super.config.apply(this, arguments);
+    if (!baseConfig.APP) {
+      return config;
+    }
+    const gitInfo = getGitInfo();
+    baseConfig.APP.commitsSinceLastTag = gitInfo.commitsSinceLastTag;
+    return config;
   },
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-nrg-ui",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "description": "Opinionated UI addon based on how KUB scaffolds web applications",
   "keywords": [
     "ember-addon",
@@ -51,6 +51,7 @@
     "ember-truth-helpers": "3.0.0",
     "ember-validators": "4.0.0",
     "fomantic-ui-css": "2.8.8",
+    "git-repo-info": "^2.1.1",
     "markdown-it": "12.3.2",
     "sass": "1.43.5",
     "walk-sync": "^3.0.0"


### PR DESCRIPTION
We expect the app version to display as the tag unless the current commit does not match what is on the tag. `ember-cli-app-version` would return just the version when there were no commits on top of the tag until [these changes](https://github.com/ember-cli/ember-cli-app-version/pull/68/files) were put into place. Now it always returns the version and commit SHA. Here I am using the same library they are to get the git info and adding the `commitsSinceLastTag` to the `APP` config. Then in the helper, if that number is 0, I try to display the extended version. If the regex match fails for that, it will try to get the unextended version. If the `commitsSinceLastTag` is not 0, then it will display the short commit SHA. To test these changes, I used yarn link to sym link this to `ember-kubapps-ui` and verified the version displayed correctly in both situations.