### PR TITLE
fix: nrg-toast progress and dismissal

### DIFF
--- a/addon/components/nrg-toast.hbs
+++ b/addon/components/nrg-toast.hbs
@@ -1,10 +1,9 @@
 <div
   role="button"
   class="floating toast-box compact transition visible"
-  {{on "mouseenter" this._mouseEnterHandler}}
-  {{on "mouseleave" this._mouseLeaveHandler}}
+  {{on "click" this.onClick}}
 >
-  {{#if this.showProgress}}
+  {{#if this.toast.showProgress}}
     <div
       class="ui attached active progress
         {{this.toast.type}}

--- a/addon/components/nrg-toast.js
+++ b/addon/components/nrg-toast.js
@@ -1,9 +1,13 @@
 import { htmlSafe } from '@ember/template';
 import FlashMessage from 'ember-cli-flash/components/flash-message';
 export default class Toast extends FlashMessage {
+  get flash() {
+    return this.toast;
+  }
+
   get progressDuration() {
-    const timeout = this.flash.timeout;
-    if (!this.showProgress) {
+    const timeout = this.toast?.timeout;
+    if (!this.toast.showProgress) {
       return '';
     }
     return htmlSafe(`animation-duration: ${timeout}ms;`);

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "ember-auto-import": "^1.11.3",
     "ember-cli-app-version": "5.0.0",
     "ember-cli-babel": "^7.26.6",
-    "ember-cli-flash": "2.1.0",
+    "ember-cli-flash": "2.2.0",
     "ember-cli-htmlbars": "^5.7.1",
     "ember-cli-sass": "10.0.1",
     "ember-concurrency": "2.2.0",

--- a/tests/dummy/app/controllers/toasts.js
+++ b/tests/dummy/app/controllers/toasts.js
@@ -55,13 +55,16 @@ export default class ToastsController extends Controller {
   openStickyToast() {
     //BEGIN-SNIPPET sticky-toasts
     this.flashMessages.info('This is a sticky info message', {
-      timeout: 0,
+      sticky: true,
+      showProgress: false,
     });
     this.flashMessages.success('This is a sticky success message', {
       sticky: true,
+      showProgress: false,
     });
     this.flashMessages.error('This is a sticky error message', {
       sticky: true,
+      showProgress: false,
     });
     //END-SNIPPET
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4823,7 +4823,7 @@ ember-cli-babel-plugin-helpers@^1.0.0, ember-cli-babel-plugin-helpers@^1.1.0, em
   resolved "https://registry.npmjs.org/ember-cli-babel-plugin-helpers/-/ember-cli-babel-plugin-helpers-1.1.1.tgz#5016b80cdef37036c4282eef2d863e1d73576879"
   integrity sha512-sKvOiPNHr5F/60NLd7SFzMpYPte/nnGkq/tMIfXejfKHIhaiIkYFqX8Z9UFTKWLLn+V7NOaby6niNPZUdvKCRw==
 
-ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.9.0:
+ember-cli-babel@^6.0.0-beta.4:
   version "6.18.0"
   resolved "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz#3f6435fd275172edeff2b634ee7b29ce74318957"
   integrity sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==
@@ -4842,7 +4842,7 @@ ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.9.0:
     ember-cli-version-checker "^2.1.2"
     semver "^5.5.0"
 
-ember-cli-babel@^7.0.0, ember-cli-babel@^7.1.2, ember-cli-babel@^7.1.3, ember-cli-babel@^7.10.0, ember-cli-babel@^7.13.0, ember-cli-babel@^7.13.2, ember-cli-babel@^7.18.0, ember-cli-babel@^7.19.0, ember-cli-babel@^7.21.0, ember-cli-babel@^7.22.1, ember-cli-babel@^7.23.0, ember-cli-babel@^7.23.1, ember-cli-babel@^7.26.3, ember-cli-babel@^7.26.5, ember-cli-babel@^7.26.6, ember-cli-babel@^7.7.3:
+ember-cli-babel@^7.0.0, ember-cli-babel@^7.1.2, ember-cli-babel@^7.1.3, ember-cli-babel@^7.10.0, ember-cli-babel@^7.13.0, ember-cli-babel@^7.13.2, ember-cli-babel@^7.19.0, ember-cli-babel@^7.21.0, ember-cli-babel@^7.22.1, ember-cli-babel@^7.23.0, ember-cli-babel@^7.23.1, ember-cli-babel@^7.26.3, ember-cli-babel@^7.26.5, ember-cli-babel@^7.26.6, ember-cli-babel@^7.7.3:
   version "7.26.11"
   resolved "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-7.26.11.tgz#50da0fe4dcd99aada499843940fec75076249a9f"
   integrity sha512-JJYeYjiz/JTn34q7F5DSOjkkZqy8qwFOOxXfE6pe9yEJqWGu4qErKxlz8I22JoVEQ/aBUO+OcKTpmctvykM9YA==
@@ -4889,14 +4889,14 @@ ember-cli-dependency-checker@^3.2.0:
     resolve "^1.5.0"
     semver "^5.3.0"
 
-ember-cli-flash@2.1.0:
-  version "2.1.0"
-  resolved "https://registry.npmjs.org/ember-cli-flash/-/ember-cli-flash-2.1.0.tgz#73730fe039f80aef264325cb85ef05fccf111eba"
-  integrity sha512-ktuX1QQGaIF1TsUEKVB2skaxnfvpciqMZ6bQkFppimkgpHU3ruypWl0Z6NRZ8jCUeXbcHOeXA+fih95CPQyxBQ==
+ember-cli-flash@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.npmjs.org/ember-cli-flash/-/ember-cli-flash-2.2.0.tgz#c95c5e2f3e82da86c4be12390fdd0f19de80a5e4"
+  integrity sha512-/s3sWmqf1mrP55BEewQxe5BoVHydOt2pIA0bO/HmvlFyS6bW0xkUoVBEJGPH42kKCTBwzpUm/D7jfbUngSCLpw==
   dependencies:
-    ember-cli-babel "^7.18.0"
-    ember-cli-htmlbars "^4.2.3"
-    ember-runtime-enumerable-includes-polyfill "^2.1.0"
+    "@ember/render-modifiers" "^1.0.2"
+    ember-cli-babel "^7.26.6"
+    ember-cli-htmlbars "^5.7.1"
 
 ember-cli-get-component-path-option@^1.0.0:
   version "1.0.0"
@@ -4913,7 +4913,7 @@ ember-cli-htmlbars@^3.0.1:
     json-stable-stringify "^1.0.1"
     strip-bom "^3.0.0"
 
-ember-cli-htmlbars@^4.2.3, ember-cli-htmlbars@^4.3.1:
+ember-cli-htmlbars@^4.3.1:
   version "4.5.0"
   resolved "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-4.5.0.tgz#d299e4f7eba6f30dc723ee086906cc550beb252e"
   integrity sha512-bYJpK1pqFu9AadDAGTw05g2LMNzY8xTCIqQm7dMJmKEoUpLRFbPf4SfHXrktzDh7Q5iggl6Skzf1M0bPlIxARw==
@@ -5505,14 +5505,6 @@ ember-router-generator@^2.0.0:
     "@babel/parser" "^7.4.5"
     "@babel/traverse" "^7.4.5"
     recast "^0.18.1"
-
-ember-runtime-enumerable-includes-polyfill@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.npmjs.org/ember-runtime-enumerable-includes-polyfill/-/ember-runtime-enumerable-includes-polyfill-2.1.0.tgz#dc6d4a028471e4acc350dfd2a149874fb20913f5"
-  integrity sha512-au18iI8VbEDYn3jLFZzETnKN5ciPgCUxMRucEP3jkq7qZ6sE0FVKpWMPY/h9tTND3VOBJt6fgPpEBJoJVCUudg==
-  dependencies:
-    ember-cli-babel "^6.9.0"
-    ember-cli-version-checker "^2.1.0"
 
 ember-source-channel-url@^1.0.1:
   version "1.2.0"


### PR DESCRIPTION
The toast progress bar was not loading as expected and clicking on them did not dismiss them. I also removed the `mouseenter` and `mouseleave` modifiers, because those are not actions and everything seems to work fine without them (progress stops on `mouseenter `and resumes on `mouseleave`). I bumped the version in the last PR and have not released it yet, so I won't need to bump it here.