### PR TITLE
feat(validations): Support nested value paths

### DIFF
--- a/addon/components/nrg-validation-component.js
+++ b/addon/components/nrg-validation-component.js
@@ -1,6 +1,7 @@
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
+import { get, set } from '@ember/object';
 
 export default class NrgValidationComponent extends Component {
   @tracked
@@ -8,7 +9,7 @@ export default class NrgValidationComponent extends Component {
 
   get value() {
     if (this.hasModelPath) {
-      return this.args.model[this.args.valuePath];
+      return get(this.args.model, this.args.valuePath);
     } else {
       return this._value;
     }
@@ -16,7 +17,7 @@ export default class NrgValidationComponent extends Component {
 
   set value(newValue) {
     if (this.hasModelPath) {
-      this.args.model[this.args.valuePath] = newValue;
+      set(this.args.model, this.args.valuePath, newValue);
     } else {
       this._value = newValue;
     }
@@ -24,10 +25,8 @@ export default class NrgValidationComponent extends Component {
 
   constructor() {
     super(...arguments);
-    if (this.hasModelPath) {
-      this.value = this.args.model[this.args.valuePath];
-    } else if (this.args.value) {
-      this.value = this.args.value;
+    if (!this.hasModelPath && this.args.value) {
+      this._value = this.args.value;
     }
 
     if (this.hasModelPath && this.args.field) {

--- a/addon/decorators/validation.js
+++ b/addon/decorators/validation.js
@@ -1,3 +1,4 @@
+import { get } from '@ember/object';
 import { typeOf } from '@ember/utils';
 import { validate } from 'ember-validators';
 import messages from 'ember-validators/messages';
@@ -24,9 +25,15 @@ export default function validationState(validatorsArgument) {
             options: {},
           };
 
-          for (const validator of validators[key]) {
+          let validatorArray = validators[key];
+
+          if (!Array.isArray(validatorArray)) {
+            validatorArray = [validatorArray];
+          }
+
+          for (const validator of validatorArray) {
             const validatorResponse = validator.apply(this, [
-              this[key],
+              get(this, key),
               messages,
             ]);
 

--- a/tests/acceptance/form-validation-test.js
+++ b/tests/acceptance/form-validation-test.js
@@ -18,18 +18,18 @@ module('Acceptance | form validation', function (hooks) {
     await click('button[type=submit]');
 
     assert
-      .dom('div.field:last-of-type > div.red.label')
+      .dom('[data-test-custom-validator] > div.red.label')
       .hasText('This is an invalid value', 'Custom error message works');
 
-    await fillIn('div.field.error:last-of-type input', 'defaultError');
+    await fillIn('[data-test-custom-validator] input', 'defaultError');
 
     assert
-      .dom('div.field:last-of-type > div.red.label')
+      .dom('[data-test-custom-validator] > div.red.label')
       .hasText('This field is not valid', 'false displays default error');
 
-    await fillIn('div.field.error:last-of-type input', 'correct');
+    await fillIn('[data-test-custom-validator] input', 'correct');
     assert
-      .dom('div.field:last-of-type > div.red.label')
+      .dom('[data-test-custom-validator] > div.red.label')
       .doesNotExist('true displays no error');
   });
 

--- a/tests/acceptance/form-validation-test.js
+++ b/tests/acceptance/form-validation-test.js
@@ -10,7 +10,7 @@ module('Acceptance | form validation', function (hooks) {
     await click('button[type=submit]');
     const errorNodes = findAll('.error');
 
-    assert.equal(errorNodes.length, 7);
+    assert.equal(errorNodes.length, 8);
   });
 
   test('Custom validators work', async function (assert) {
@@ -31,5 +31,21 @@ module('Acceptance | form validation', function (hooks) {
     assert
       .dom('div.field:last-of-type > div.red.label')
       .doesNotExist('true displays no error');
+  });
+
+  test('Nested validators work', async function (assert) {
+    await visit('/validation-tests');
+    await click('button[type=submit]');
+
+    const controller = this.owner.lookup('controller:validation-tests');
+
+    assert
+      .dom('[data-test-nested-validator] > div.red.label')
+      .hasText("This field can't be blank");
+
+    await fillIn('[data-test-nested-validator] input', 'text');
+    assert.dom('[data-test-nested-validator] > div.red.label').doesNotExist();
+
+    assert.equal(controller.nested.field, 'text', 'nested value paths work');
   });
 });

--- a/tests/dummy/app/controllers/validation-tests.js
+++ b/tests/dummy/app/controllers/validation-tests.js
@@ -22,6 +22,7 @@ const Validators = {
       },
     }),
   ],
+  'nested.field': validator('presence', true),
 };
 
 export default class ValidationTestsController extends Controller {
@@ -58,4 +59,10 @@ export default class ValidationTestsController extends Controller {
 
   @tracked
   customValidation;
+
+  @tracked
+  nested = new (class {
+    @tracked
+    field;
+  })();
 }

--- a/tests/dummy/app/templates/validation-tests.hbs
+++ b/tests/dummy/app/templates/validation-tests.hbs
@@ -45,7 +45,7 @@
     />
   </form.field>
 
-  <form.field @label="Custom Validation" as |field|>
+  <form.field @label="Custom Validation" data-test-custom-validator as |field|>
     <field.text-field @model={{this}} @valuePath="customValidation" />
   </form.field>
 

--- a/tests/dummy/app/templates/validation-tests.hbs
+++ b/tests/dummy/app/templates/validation-tests.hbs
@@ -49,5 +49,9 @@
     <field.text-field @model={{this}} @valuePath="customValidation" />
   </form.field>
 
+  <form.field @label="Nested Validations" data-test-nested-validator as |field|>
+    <field.text-field @model={{this}} @valuePath="nested.field" />
+  </form.field>
+
   <form.submit-button />
 </NrgFormContainer>


### PR DESCRIPTION
The following changes were made:
* The `valuePath` property for all components extending `NrgValidationComponent` now supports nested values. This allows a property referencing a property on an object in the model to be used
* Validators support nested properties, where the key should be period-separated, eg. `nested.field`
* A single validator for a key in the validators object does not have to be wrapped in an array, it can be passed directly