### PR TITLE
feat(lightbox): Move details location to service to persist across user session

### DIFF
--- a/addon/components/nrg-lightbox-container.js
+++ b/addon/components/nrg-lightbox-container.js
@@ -10,8 +10,9 @@ export default class NrgPopupComponent extends Component {
   @tracked
   rotationClass;
 
-  @tracked
-  bottomDetails = false;
+  get bottomDetails() {
+    return this.lightboxService.bottomDetails;
+  }
 
   @action
   onModalOpen() {
@@ -35,7 +36,7 @@ export default class NrgPopupComponent extends Component {
 
   @action
   toggleDetailLocation() {
-    this.bottomDetails = !this.bottomDetails;
+    this.lightboxService.bottomDetails = !this.bottomDetails;
   }
 
   @action

--- a/addon/services/lightbox.js
+++ b/addon/services/lightbox.js
@@ -17,6 +17,9 @@ export default class LightboxService extends Service {
   @tracked
   selectedPhotoDetail;
 
+  @tracked
+  bottomDetails = false;
+
   get hasChildren() {
     return this.items?.length > 0;
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-nrg-ui",
-  "version": "3.6.7",
+  "version": "3.6.8",
   "description": "Opinionated UI addon based on how KUB scaffolds web applications",
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
Previously, the details would default to the side of the modal on each render. This change allows the user selected location to persist across modal opens/closes within the same user session.