### PR TITLE
feat(lightbox): Move bottomDetails to service and add ability to fire action on change

### DIFF
--- a/addon/components/nrg-lightbox-container.js
+++ b/addon/components/nrg-lightbox-container.js
@@ -10,8 +10,13 @@ export default class NrgPopupComponent extends Component {
   @tracked
   rotationClass;
 
-  @tracked
-  bottomDetails = false;
+  get bottomDetails() {
+    return this.lightboxService.bottomDetails;
+  }
+
+  set bottomDetails(bottomDetails) {
+    this.lightboxService.bottomDetails = bottomDetails;
+  }
 
   @action
   onModalOpen() {
@@ -36,6 +41,7 @@ export default class NrgPopupComponent extends Component {
   @action
   toggleDetailLocation() {
     this.bottomDetails = !this.bottomDetails;
+    this.lightboxService.onBottomDetailsChange?.(this.bottomDetails);
   }
 
   @action

--- a/addon/components/nrg-lightbox-thumbnail.js
+++ b/addon/components/nrg-lightbox-thumbnail.js
@@ -11,6 +11,13 @@ export default class NrgLightboxThumbnailComponent extends Component {
   @tracked
   detail;
 
+  constructor() {
+    super(...arguments);
+    this.lightboxService.bottomDetails = this.args.bottomDetails ?? false;
+    this.lightboxService.onBottomDetailsChange =
+      this.args.onBottomDetailsChange;
+  }
+
   thumbnailId = 'thumbnail-' + guidFor(this);
 
   @action

--- a/addon/services/lightbox.js
+++ b/addon/services/lightbox.js
@@ -17,6 +17,9 @@ export default class LightboxService extends Service {
   @tracked
   selectedPhotoDetail;
 
+  @tracked
+  bottomDetails = false;
+
   get hasChildren() {
     return this.items?.length > 0;
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-nrg-ui",
-  "version": "3.6.8",
+  "version": "3.6.9",
   "description": "Opinionated UI addon based on how KUB scaffolds web applications",
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
By moving the `bottomDetails` property to the `lightbox` service, it can now be set when invoking the `NrgLightboxThumbnail` with `@bottomDetails` argument, and changes to the details location selected can be handled with the `@onBottomDetailsChange` argument. 