### PR TITLE
chore: Bump version to 3.6.10 for release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-nrg-ui",
-  "version": "3.6.9",
+  "version": "3.6.10",
   "description": "Opinionated UI addon based on how KUB scaffolds web applications",
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
Bumps release version because I forgot to include version bump for release in PR https://github.com/knoxville-utilities-board/ember-nrg-ui/pull/454