### PR TITLE
feat: Allow nrg-app-version to get Electron version

### DIFF
--- a/addon/components/nrg-appbar/component.js
+++ b/addon/components/nrg-appbar/component.js
@@ -5,6 +5,9 @@ import ResizeMixin from 'ember-nrg-ui/mixins/resize';
 import Component from '@ember/component';
 import layout from './template';
 import { getOwner } from '@ember/application';
+import { task } from 'ember-concurrency';
+import { appVersion, electronAppVersion } from 'ember-nrg-ui/utils/nrg-app-version';
+
 
 export default Component.extend(ResizeMixin, {
   layout,
@@ -18,6 +21,24 @@ export default Component.extend(ResizeMixin, {
   isMobileScreen: alias('responsive.isMobileScreenGroup'),
 
   showReleaseNotes: true,
+
+  appVersion,
+
+  init() {
+    this._super(...arguments);
+
+    if (window.ELECTRON) {
+      this.getElectronAppVersion.perform();
+    } else {
+      this.set('appVersion', appVersion());
+    }
+  },
+
+  getElectronAppVersion: task(function* () {
+    const appVersion = yield electronAppVersion();
+
+    this.set('appVersion', appVersion);
+  }),
 
   environmentDisplay: computed('applicationSettings.localEnvironment', function() {
     const ENV = getOwner(this).resolveRegistration('config:environment');

--- a/addon/components/nrg-appbar/template.hbs
+++ b/addon/components/nrg-appbar/template.hbs
@@ -20,7 +20,7 @@
     {{yield}}
     {{#if showReleaseNotes}}
       <div class="item">
-        <LinkTo @route="release-notes">{{nrg-app-version}}</LinkTo>
+        <LinkTo @route="release-notes">{{appVersion}}</LinkTo>
       </div>
     {{/if}}
     <NrgContextMenu />

--- a/addon/utils/nrg-app-version.js
+++ b/addon/utils/nrg-app-version.js
@@ -1,10 +1,15 @@
-import { helper } from '@ember/component/helper';
 import config from 'ember-get-config';
 import { shaRegExp } from 'ember-cli-app-version/utils/regexp';
 
 const {
   APP: { version },
 } = config;
+
+export async function electronAppVersion() {
+    const electronAppVersion = await window.electronBridge.getCurrentElectronAppVersion();
+
+    return electronAppVersion;
+}
 
 export function appVersion() {
   const parts = version.split('+');
@@ -18,4 +23,4 @@ export function appVersion() {
   return displayVersion;
 }
 
-export default helper(appVersion);
+export default appVersion;

--- a/app/helpers/nrg-app-version.js
+++ b/app/helpers/nrg-app-version.js
@@ -1,1 +1,0 @@
-export { default, appVersion } from 'ember-nrg-ui/helpers/nrg-app-version';

--- a/app/utils/nrg-app-version.js
+++ b/app/utils/nrg-app-version.js
@@ -1,0 +1,1 @@
+export { default, electronAppVersion, appVersion } from 'ember-nrg-ui/utils/nrg-app-version';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-nrg-ui",
-  "version": "2.5.9",
+  "version": "2.6.0",
   "description": "Opinionated UI addon based on how KUB scaffolds web applications",
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
This is to allow for a way for Electron to set the correct app version in the app bar. This needs to be asynchronous for the Electron bridge to communicate with the render process, so I've converted `nrg-app-version` to a util.