### PR TITLE
chore(side-by-side): Bump CSS specificity to fix border with lists

### DIFF
--- a/addon/styles/_side-by-side.scss
+++ b/addon/styles/_side-by-side.scss
@@ -13,7 +13,7 @@
   }
 
   &--primary {
-    .nrg-list.nrg-list {
+    .nrg-list.nrg-list.nrg-list {
       border: none;
     }
     width: 40% !important;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-nrg-ui",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "description": "Opinionated UI addon based on how KUB scaffolds web applications",
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
Recently (likely with the bump of Fomantic UI), lists used in the primary section of a side-by-side have an extra border visible:
![image](https://github.com/knoxville-utilities-board/ember-nrg-ui/assets/7104823/6b5d14cd-7680-4ab0-bd88-ce564e09e3fd)

Increasing the specificity of an existing rule fixes this issue:
![image](https://github.com/knoxville-utilities-board/ember-nrg-ui/assets/7104823/0dd4b498-98a0-4bd9-8e36-f4ce904410ba)
