### PR TITLE
feat(search): Display input value dynamically

### DIFF
--- a/addon/components/nrg-search.hbs
+++ b/addon/components/nrg-search.hbs
@@ -18,7 +18,7 @@
       @placeholder={{this.placeholder}}
       @readonly={{@readonly}}
       @model={{this}}
-      @valuePath="searchString"
+      @valuePath="displayValue"
       @onChange={{this.query}}
     />
     {{#unless @hideSearchIcon}}

--- a/addon/components/nrg-search.js
+++ b/addon/components/nrg-search.js
@@ -22,15 +22,10 @@ export default class NrgSearchComponent extends NrgValidationComponent {
   activeItem = -1;
 
   @tracked
-  searchString = '';
+  searchString = null;
 
   @tracked
   items = null;
-
-  constructor() {
-    super(...arguments);
-    this.updateDisplayValue(this.value);
-  }
 
   get isTesting() {
     return this.application.isTesting ?? false;
@@ -84,9 +79,13 @@ export default class NrgSearchComponent extends NrgValidationComponent {
     );
   }
 
-  updateDisplayValue(selected) {
-    const displayLabel = get(selected ?? {}, this.displayLabel);
-    this.searchString = displayLabel ?? this.value ?? '';
+  get displayValue() {
+    const displayLabel = get(this.value ?? {}, this.displayLabel);
+    return this.searchString ?? displayLabel ?? this.value ?? '';
+  }
+
+  set displayValue(value) {
+    this.searchString = value;
   }
 
   selectItem(item) {
@@ -94,7 +93,7 @@ export default class NrgSearchComponent extends NrgValidationComponent {
       item = this.items[this.activeItem];
     }
     this.onChange(item);
-    this.updateDisplayValue(item);
+    this.searchString = null;
     this.onBlur();
   }
 

--- a/addon/components/nrg-search.js
+++ b/addon/components/nrg-search.js
@@ -63,7 +63,7 @@ export default class NrgSearchComponent extends NrgValidationComponent {
   }
 
   get canPerformSearch() {
-    return this.searchString.length >= this.minCharacters;
+    return this.searchString?.length >= this.minCharacters;
   }
 
   get receivedResults() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-nrg-ui",
-  "version": "4.1.5",
+  "version": "4.1.6",
   "description": "Opinionated UI addon based on how KUB scaffolds web applications",
   "keywords": [
     "ember-addon",

--- a/tests/integration/components/nrg-search-test.js
+++ b/tests/integration/components/nrg-search-test.js
@@ -1,4 +1,5 @@
-import { fillIn, findAll, render } from '@ember/test-helpers';
+import { fillIn, findAll, render, settled } from '@ember/test-helpers';
+import { tracked } from '@glimmer/tracking';
 import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import { module, test } from 'qunit';
@@ -59,5 +60,28 @@ module('Integration | Component | nrg-search', function (hooks) {
 
     assert.dom('.search input').hasAttribute('readonly');
     assert.dom('.search input').isNotDisabled();
+  });
+
+  test('input value updates dynamically', async function (assert) {
+    class Model {
+      @tracked
+      valuePath = 'prop1';
+
+      prop1 = 'value1';
+      prop2 = 'value2';
+    }
+
+    this.model = new Model();
+
+    await render(
+      hbs`<NrgSearch @model={{this.model}} @valuePath={{this.model.valuePath}} />`
+    );
+
+    assert.dom('input').hasValue('value1');
+
+    this.model.valuePath = 'prop2';
+    await settled();
+
+    assert.dom('input').hasValue('value2');
   });
 });


### PR DESCRIPTION
Previously, the search component would only compute what value to display on initial rendering - meaning if the underlying model/valuePath changed, the displayed text would not be updated.