### PR TITLE
fix: default set date value if undefined

### DIFF
--- a/addon/components/nrg-datetime/calendar/component.js
+++ b/addon/components/nrg-datetime/calendar/component.js
@@ -43,6 +43,9 @@ export default Component.extend(EKMixin, EKFirstResponderOnFocusMixin, {
     } else if (this.type === 'time') {
       this.set('isSelectingHours', true);
     }
+    if (!this.value) {
+      this.value = new Date();
+    }
     this._updateSelectedIndexes(this.value);
   },
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-nrg-ui",
-  "version": "2.5.11",
+  "version": "2.5.12",
   "description": "Opinionated UI addon based on how KUB scaffolds web applications",
   "keywords": [
     "ember-addon",

--- a/tests/integration/components/nrg-datetime/calendar/component-test.js
+++ b/tests/integration/components/nrg-datetime/calendar/component-test.js
@@ -185,21 +185,7 @@ module('Integration | Component | nrg-datetime/calendar', function(hooks) {
     assert.notOk(find('tbody tr:nth-child(7)'));
   });
 
-  test('no time is selected if no value is passed in', async function(assert) {
-    await render(hbs`<NrgDatetime::Calendar @type="time" @value={{value}} />`);
-    
-    const selected = findAll('div.calendar.visible td.active');
-    assert.equal(selected.length, 0);
-  });
-
-  test('no date is selected if no value is passed in', async function(assert) {
-    await render(hbs`<NrgDatetime::Calendar @type="date" @value={{value}} />`);
-    
-    const selected = findAll('div.calendar.visible td.active');
-    assert.equal(selected.length, 0);
-  });
-
-  test('isDateDisabled can use precision', async function(assert) {
+  test('isDateDisabled can use precision', async function (assert) {
     const hour = 8;
     const minute = 15;
     const minDate = moment({


### PR DESCRIPTION
This change fixes the error with the Datetime Calendar that was causing the calendar to be greyed out upon first click.