### PR TITLE
fix: don't show text of items when multiselect

### DIFF
--- a/addon/components/nrg-dropdown.hbs
+++ b/addon/components/nrg-dropdown.hbs
@@ -38,7 +38,7 @@
       <i class="icon {{@icon}}"></i>
     {{/if}}
 
-    {{#if this.displayDefaultText}}
+    {{#if (and this.displayDefaultText (not @multiple))}}
       <div class="{{this.textClass}} text">
         {{#if this.hasSelected}}
           {{#if (has-block)}}
@@ -53,27 +53,36 @@
         {{/if}}
       </div>
     {{/if}}
-    {{#if (and @multiple this.hasSelected)}}
-      {{#each this.value as |selectedOption|}}
-        <div
-          data-dropdown-multi-selection="true"
-          class="ui label transition visible"
-        >
-          {{#if (has-block)}}
-            {{yield selectedOption}}
-          {{else if this.isStringData}}
-            {{selectedOption}}
-          {{else}}
-            {{selectedOption.label}}
-          {{/if}}
-          <i
+
+    {{#if (and @multiple)}}
+      {{#if this.hasSelected}}
+        {{#each this.value as |selectedOption|}}
+          <div
             data-dropdown-multi-selection="true"
-            class="delete icon"
-            role="button"
-            {{on "click" (fn this.unselectOption selectedOption)}}
-          ></i>
-        </div>
-      {{/each}}
+            class="ui label transition visible"
+          >
+            {{#if (has-block)}}
+              {{yield selectedOption}}
+            {{else if this.isStringData}}
+              {{selectedOption}}
+            {{else}}
+              {{selectedOption.label}}
+            {{/if}}
+            <i
+              data-dropdown-multi-selection="true"
+              class="delete icon"
+              role="button"
+              {{on "click" (fn this.unselectOption selectedOption)}}
+            ></i>
+          </div>
+        {{/each}}
+      {{else}}
+        {{#if this.displayDefaultText}}
+          <div class="{{this.textClass}} text">
+            {{this.defaultText}}
+          </div>
+        {{/if}}
+      {{/if}}
     {{/if}}
     {{#if @search}}
       <input

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-nrg-ui",
-  "version": "4.1.10",
+  "version": "4.1.11",
   "description": "Opinionated UI addon based on how KUB scaffolds web applications",
   "keywords": [
     "ember-addon",

--- a/tests/dummy/app/components/freestyle/forms/dropdown.hbs
+++ b/tests/dummy/app/components/freestyle/forms/dropdown.hbs
@@ -7,6 +7,7 @@
             <field.dropdown
               @disabled={{this.dropdownDisabled}}
               @readonly={{this.dropdownReadonly}}
+              @multiple={{this.dropdownMulti}}
               @valuePath="dropdownValue"
               @model={{this}}
               @options={{this.dropdownOptions}}
@@ -27,6 +28,12 @@
           @defaultValue={{false}}
           @value={{this.dropdownReadonly}}
           @onInput={{fn (mut this.dropdownReadonly)}}
+        />
+        <Args.Bool
+          @name="multiple"
+          @defaultValue={{false}}
+          @value={{this.dropdownMulti}}
+          @onInput={{fn (mut this.dropdownMulti)}}
         />
       </:api>
     </Freestyle::Usage>


### PR DESCRIPTION
When using the multiselect it will display the options as text in addition to the selectable buttons.

Before:

<img width="834" alt="Screenshot 2023-08-17 163439" src="https://github.com/knoxville-utilities-board/ember-nrg-ui/assets/32367147/066666a3-3027-429f-97c2-ed44db1afc7b">

After:

<img width="833" alt="Screenshot 2023-08-17 163344" src="https://github.com/knoxville-utilities-board/ember-nrg-ui/assets/32367147/2b7953b5-597f-4dfa-8152-90a3f9121ccd">


It appears that the condition changed from 2.x to 4.x