### PR TITLE
fix(nrg-list): Prevent forced deprecation warning

### DIFF
--- a/addon/components/nrg-list.hbs
+++ b/addon/components/nrg-list.hbs
@@ -23,7 +23,8 @@
         loading=@loading
         items=@items
         onChange=@onChange
-        onItemSelect=this.onItemSelect
+        onItemClick=@onItemClick
+        onItemSelect=@onItemSelect
         onChangePage=this.onChangePage
         groupHeaderHandler=this.groupHeaderHandler
       )
@@ -45,7 +46,8 @@
     @loading={{@loading}}
     @items={{@items}}
     @onChange={{@onChange}}
-    @onItemSelect={{this.onItemSelect}}
+    @onItemClick={{@onItemClick}}
+    @onItemSelect={{@onItemSelect}}
     @onChangePage={{this.onChangePage}}
     @groupHeaderHandler={{this.groupHeaderHandler}}
   />

--- a/addon/components/nrg-list.js
+++ b/addon/components/nrg-list.js
@@ -70,11 +70,6 @@ export default class NrgListComponent extends Component {
   }
 
   @action
-  onItemSelect() {
-    this.args.onItemSelect?.(...arguments);
-  }
-
-  @action
   onChangePage() {
     this.args.onChangePage?.(...arguments);
   }

--- a/addon/components/nrg-list/items.js
+++ b/addon/components/nrg-list/items.js
@@ -1,4 +1,4 @@
-import { A } from '@ember/array';
+import { A, isArray } from '@ember/array';
 import { action } from '@ember/object';
 import { isEmpty } from '@ember/utils';
 import NrgValidationComponent from 'ember-nrg-ui/components/nrg-validation-component';
@@ -6,6 +6,13 @@ import { deprecate } from '@ember/debug';
 import { tracked } from '@glimmer/tracking';
 
 const defaultNoResultsLabel = 'No Results';
+
+function ensureArray(value) {
+  if (isArray(value)) {
+    return value;
+  }
+  return A([value]);
+}
 
 export default class NrgListItemsComponent extends NrgValidationComponent {
   @tracked
@@ -56,7 +63,9 @@ export default class NrgListItemsComponent extends NrgValidationComponent {
   }
 
   @action
-  onItemClick(item) {
+  onItemClick(item, evt) {
+    evt?.preventDefault();
+    evt?.stopPropagation();
     const selectionType = this.args.selectionType;
 
     if (!selectionType || selectionType === 'click') {
@@ -87,6 +96,7 @@ export default class NrgListItemsComponent extends NrgValidationComponent {
     }
 
     if (selectionType === 'multiple') {
+      allSelected = ensureArray(allSelected);
       if (allSelected.includes(item)) {
         allSelected.removeObject(item);
       } else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-nrg-ui",
-  "version": "4.5.0",
+  "version": "4.5.1",
   "description": "Opinionated UI addon based on how KUB scaffolds web applications",
   "keywords": [
     "ember-addon",

--- a/tests/dummy/app/components/freestyle/list.hbs
+++ b/tests/dummy/app/components/freestyle/list.hbs
@@ -5,7 +5,8 @@
         @items={{this.pagedItems}}
         @pageMeta={{this.pagedItems.meta}}
         @onQuery={{this.onQuery}}
-        @onItemSelect={{this.onItemSelect}}
+        @onItemClick={{fn this.onItemClick "onItemClick"}}
+        @onChange={{fn this.onItemClick "onChange"}}
         @selectionType={{this.selectionType}}
         @loading={{this.loading}}
         @onChangePage={{this.onChangePage}}
@@ -18,7 +19,7 @@
         </list.header>
         <list.items as |item|>
           <div class="content">
-            <a href="" class="header">{{item.name}}</a>
+            <span class="header">{{item.name}}</span>
             <div class="meta">
               <span>{{item.meta}}</span>
             </div>
@@ -57,7 +58,7 @@
       <NrgList
         @groupHeaderHandler={{this.groupHeaderHandler}}
         @items={{this.mappedItems}}
-        @onItemSelect={{this.onItemSelect}}
+        @onItemClick={{this.onItemClick}}
       />
     </:example>
   </Freestyle::Usage>

--- a/tests/dummy/app/components/freestyle/list.js
+++ b/tests/dummy/app/components/freestyle/list.js
@@ -1,5 +1,4 @@
 import Component from '@glimmer/component';
-import { debug } from '@ember/debug';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 
@@ -68,7 +67,7 @@ export default class FreestyleListComponent extends Component {
   @tracked
   selectedPageSize = 2;
 
-  selectionTypeOptions = ['', 'single', 'multiple'];
+  selectionTypeOptions = ['', 'click', 'single', 'multiple'];
 
   get filteredItems() {
     let items = defaultList;
@@ -129,8 +128,8 @@ export default class FreestyleListComponent extends Component {
   }
 
   @action
-  onItemSelect() {
-    debug('item selected', ...arguments);
+  onItemClick() {
+    console.log('item clicked', ...arguments);
   }
 
   @action


### PR DESCRIPTION
* Internally, the `nrg-list` component referenced actions that have since been deprecated on the `nrg-list/items` component. This has been resolved.
* Changing the `selectionType` of a list from `single` to `multiple` would break in determining if the newly selected item was included in the array of selected items.