### PR TITLE
fix(whats-new): Allow "What's New" modal to appear

### DIFF
--- a/addon/components/nrg-modal.hbs
+++ b/addon/components/nrg-modal.hbs
@@ -1,4 +1,4 @@
-<div hidden={{this.isHidden}}>
+<div hidden={{this.isHidden}} ...attributes>
   {{#if @isOpen}}
     <div
       {{did-insert this.addToService}}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-nrg-ui",
-  "version": "4.6.5",
+  "version": "4.6.6",
   "description": "Opinionated UI addon based on how KUB scaffolds web applications",
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
The `did-insert` modifier that the `nrg-new-features` component passes to the `nrg-modal` component is never attached to a DOM element, since no passed-in attributes to `nrg-modal` components are used anywhere. This worked in previous Ember versions since all Ember components are wrapped in a `div` by default, which is also where attributes were placed. Therefore, the modifier was placed on the `div` wrapping the modal component; this `div` no longer exists.